### PR TITLE
Error fixed on conversationScreen - a new message disappeared previously

### DIFF
--- a/screens/ConversationScreen.js
+++ b/screens/ConversationScreen.js
@@ -33,7 +33,15 @@ function ConversationScreen({ route, navigation }) {
     setRefreshing(true);
     getConversation(token, username)
       .then((conversation) => {
-        setData(conversation);
+        setData((prevData) => {
+          const newMessages = conversation.filter(
+            (newMsg) =>
+              !prevData.some(
+                (prevMsg) => prevMsg.message_id === newMsg.message_id
+              )
+          );
+          return [...prevData, ...newMessages];
+        });
         if (conversation.length > 0) {
           const message = conversation[0];
           const recipientId =

--- a/screens/MessageScreen.js
+++ b/screens/MessageScreen.js
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
     paddingTop: 65,
     fontSize: 30,
     fontWeight: "bold",
-    color: "white"
+    color: "white",
   },
   itemContainer: {
     flexDirection: "row",


### PR DESCRIPTION
Replaces the entire data state with the newly fetched conversation, which can cause new messages to disappear if the state is overwritten.